### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The package can be installed as:
 ### Standalone
 
     git clone git@github.com:mustafaturan/shield.git
-    cd shields
+    cd shield
     mix deps.get
     mix ecto.create -r Authable.Repo
     mix ecto.migrate -r Authable.Repo


### PR DESCRIPTION
Remove trailing `s` from `shields` directory after git clone.
